### PR TITLE
Worttausch

### DIFF
--- a/ableitung.tex
+++ b/ableitung.tex
@@ -378,7 +378,7 @@ zulassen.
   Abweichung $|\ddx f(x_1) - \frac{\Delta f}{\Delta x}(x_1,x_2)|$
   nicht größer als $\eps$ wird, wenn wir uns auf Stellen $x_2$
   ungleich $x_1$ beschränken, die einen (von $\eps$ abhängigen)
-  Maximalabstand $\delta>0$ von $x_1$ haben.
+  Maximalabstand $\delta>0$ von $x_1$ nicht überschreiten.
 \end{Def}
 
 Als Beispiel ermitteln wir die Ableitung von $f(x)=x^2$ an der Stelle $x=x_1:=0.5$.


### PR DESCRIPTION
"haben" in Zeile 381 durch "nicht überschreiten" ausgetauscht.